### PR TITLE
Use default C flags

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -1,5 +1,4 @@
 (library
  (public_name hacl_x25519)
  (libraries cstruct)
- (c_names hacl_x25519_stubs Hacl_Curve25519)
- (c_flags -fwrapv -fomit-frame-pointer -funroll-loops))
+ (c_names hacl_x25519_stubs Hacl_Curve25519))


### PR DESCRIPTION
After checking with Project Everest members, the C library does not rely on any particular C flags, so let us keep the default ones.