### PR TITLE
Add CAMLparam/CAMLreturn

### DIFF
--- a/src/hacl_x25519_stubs.c
+++ b/src/hacl_x25519_stubs.c
@@ -1,11 +1,13 @@
 #include <caml/mlvalues.h>
 #include <caml/bigarray.h>
+#include <caml/memory.h>
 #include "Hacl_Curve25519.h"
 
 CAMLprim value ml_Hacl_Curve25519_crypto_scalarmult(value pk, value sk, value basepoint) {
+    CAMLparam3(pk, sk, basepoint);
     Hacl_Curve25519_crypto_scalarmult(Caml_ba_data_val(pk),
                                       Caml_ba_data_val(sk),
                                       Caml_ba_data_val(basepoint));
-    return Val_unit;
+    CAMLreturn(Val_unit);
 }
 


### PR DESCRIPTION
This function does not allocate so it is probably not necessary, but better be safe than sorry.