### PR TITLE
Remove trailing spaces in hexdump output

### DIFF
--- a/hacl_x25519.opam
+++ b/hacl_x25519.opam
@@ -16,7 +16,7 @@ build: [
 ]
 depends: [
   "dune" {build & >= "1.4.0"}
-  "cstruct" {>= "3.2.0"}
+  "cstruct" {>= "3.5.0"}
   "ppx_deriving_yojson" {with-test}
   "yojson" {with-test}
   "hex" {with-test}

--- a/test/test.expected
+++ b/test/test.expected
@@ -1,19 +1,19 @@
 ok:
-9c 64 7d 9a e5 89 b9 f5  8f dc 3c a4 94 7e fb c9 
-15 c4 b2 e0 8e 74 4a 0e  df 46 9d ac 59 c8 f8 5a 
+9c 64 7d 9a e5 89 b9 f5  8f dc 3c a4 94 7e fb c9
+15 c4 b2 e0 8e 74 4a 0e  df 46 9d ac 59 c8 f8 5a
 
 public too short: error: Invalid key size
 public too long: error: Invalid key size
 alice_public:
-85 20 f0 09 89 30 a7 54  74 8b 7d dc b4 3e f7 5a 
-0d bf 3a 0d 26 38 1a f4  eb a4 a9 8e aa 9b 4e 6a 
+85 20 f0 09 89 30 a7 54  74 8b 7d dc b4 3e f7 5a
+0d bf 3a 0d 26 38 1a f4  eb a4 a9 8e aa 9b 4e 6a
 bob_public:
-de 9e db 7d 7b 7d c1 b4  d3 5b 61 c2 ec e4 35 37 
-3f 83 43 c8 5b 78 67 4d  ad fc 7e 14 6f 88 2b 4f 
+de 9e db 7d 7b 7d c1 b4  d3 5b 61 c2 ec e4 35 37
+3f 83 43 c8 5b 78 67 4d  ad fc 7e 14 6f 88 2b 4f
 pub_a * priv_b =
-4a 5d 9d 5b a4 ce 2d e1  72 8e 3b f4 80 35 0f 25 
-e0 7e 21 c9 47 d1 9e 33  76 f0 9b 3c 1e 16 17 42 
+4a 5d 9d 5b a4 ce 2d e1  72 8e 3b f4 80 35 0f 25
+e0 7e 21 c9 47 d1 9e 33  76 f0 9b 3c 1e 16 17 42
 pub_b * priv_a =
-4a 5d 9d 5b a4 ce 2d e1  72 8e 3b f4 80 35 0f 25 
-e0 7e 21 c9 47 d1 9e 33  76 f0 9b 3c 1e 16 17 42 
+4a 5d 9d 5b a4 ce 2d e1  72 8e 3b f4 80 35 0f 25
+e0 7e 21 c9 47 d1 9e 33  76 f0 9b 3c 1e 16 17 42
 


### PR DESCRIPTION
This was caused by a cstruct update.