### PR TITLE
Simplify types

### DIFF
--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -18,7 +18,7 @@ let random_private_key () =
 let bench_dh () =
   let priv = random_private_key () in
   let pub = Hacl_x25519.public @@ random_private_key () in
-  let run () : (Cstruct.t, _) result = Hacl_x25519.key_exchange ~priv ~pub in
+  let run () : (Cstruct.t, _) result = Hacl_x25519.key_exchange priv pub in
   Benchmark.throughputN 1 [("X25519", run, ())]
 
 let () =

--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -12,7 +12,7 @@ let of_ok = function
 let random_private_key () =
   crypto_random_bytes 32
   |> Cstruct.of_string
-  |> Hacl_x25519.of_cstruct
+  |> Hacl_x25519.priv_key_of_cstruct
   |> of_ok
 
 let bench_dh () =

--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -18,7 +18,7 @@ let random_private_key () =
 let bench_dh () =
   let priv = random_private_key () in
   let pub = Hacl_x25519.public @@ random_private_key () in
-  let run () : Cstruct.t = Hacl_x25519.key_exchange ~priv ~pub in
+  let run () : (Cstruct.t, _) result = Hacl_x25519.key_exchange ~priv ~pub in
   Benchmark.throughputN 1 [("X25519", run, ())]
 
 let () =

--- a/src/hacl_x25519.ml
+++ b/src/hacl_x25519.ml
@@ -1,5 +1,11 @@
 let key_length_bytes = 32
 
+type error = [`Invalid_length]
+
+let pp_error ppf = function
+  | `Invalid_length ->
+      Format.fprintf ppf "Invalid key size"
+
 type key = [`Checked of Cstruct.t]
 
 type pub_key = key
@@ -8,7 +14,7 @@ type priv_key = key
 
 let of_cstruct cs =
   if Cstruct.len cs = key_length_bytes then Ok (`Checked cs)
-  else Error "Invalid key size"
+  else Error `Invalid_length
 
 let pub_key_of_cstruct = of_cstruct
 

--- a/src/hacl_x25519.ml
+++ b/src/hacl_x25519.ml
@@ -13,7 +13,7 @@ let pp_error ppf = function
   | `Invalid_length ->
       Format.fprintf ppf "Invalid key size"
 
-type priv_key = [`Checked of Cstruct.t]
+type secret = [`Checked of Cstruct.t]
 
 let of_cstruct cs =
   if Cstruct.len cs = key_length_bytes then Ok (`Checked cs)
@@ -37,7 +37,7 @@ let key_exchange_buffer ~priv ~checked_pub =
   scalarmult_raw (checked_buffer result) (checked_buffer priv) checked_pub;
   cs
 
-let key_exchange ~priv ~pub =
+let key_exchange priv pub =
   of_cstruct pub
   >>| checked_buffer
   >>| fun checked_pub -> key_exchange_buffer ~priv ~checked_pub

--- a/src/hacl_x25519.ml
+++ b/src/hacl_x25519.ml
@@ -1,30 +1,27 @@
 let key_length_bytes = 32
 
+let ( >>| ) r f =
+  match r with
+  | Ok x ->
+      Ok (f x)
+  | Error _ as e ->
+      e
+
 type error = [`Invalid_length]
 
 let pp_error ppf = function
   | `Invalid_length ->
       Format.fprintf ppf "Invalid key size"
 
-type key = [`Checked of Cstruct.t]
-
-type pub_key = key
-
-type priv_key = key
+type priv_key = [`Checked of Cstruct.t]
 
 let of_cstruct cs =
   if Cstruct.len cs = key_length_bytes then Ok (`Checked cs)
   else Error `Invalid_length
 
-let pub_key_of_cstruct = of_cstruct
-
 let priv_key_of_cstruct = of_cstruct
 
-let to_cstruct (`Checked cs) = cs
-
-let pub_key_to_cstruct = to_cstruct
-
-let priv_key_to_cstruct = to_cstruct
+let priv_key_to_cstruct (`Checked cs) = cs
 
 (* pk -> sk -> basepoint -> unit *)
 external scalarmult_raw :
@@ -34,15 +31,19 @@ external scalarmult_raw :
 
 let checked_buffer (`Checked cs) = Cstruct.to_bigarray cs
 
-let key_exchange ~priv ~pub =
+let key_exchange_buffer ~priv ~checked_pub =
   let cs = Cstruct.create key_length_bytes in
   let result = `Checked cs in
-  scalarmult_raw (checked_buffer result) (checked_buffer priv)
-    (checked_buffer pub);
+  scalarmult_raw (checked_buffer result) (checked_buffer priv) checked_pub;
   cs
+
+let key_exchange ~priv ~pub =
+  of_cstruct pub
+  >>| checked_buffer
+  >>| fun checked_pub -> key_exchange_buffer ~priv ~checked_pub
 
 let basepoint =
   let cs = Cstruct.create key_length_bytes in
-  Cstruct.set_uint8 cs 0 9; `Checked cs
+  Cstruct.set_uint8 cs 0 9; Cstruct.to_bigarray cs
 
-let public priv = `Checked (key_exchange ~priv ~pub:basepoint)
+let public priv = key_exchange_buffer ~priv ~checked_pub:basepoint

--- a/src/hacl_x25519.ml
+++ b/src/hacl_x25519.ml
@@ -1,20 +1,24 @@
 let key_length_bytes = 32
 
-type pub
+type key = [`Checked of Cstruct.t]
 
-type priv
+type pub_key = key
 
-type _ key = [`Checked of Cstruct.t]
-
-type pub_key = pub key
-
-type priv_key = priv key
+type priv_key = key
 
 let of_cstruct cs =
   if Cstruct.len cs = key_length_bytes then Ok (`Checked cs)
   else Error "Invalid key size"
 
+let pub_key_of_cstruct = of_cstruct
+
+let priv_key_of_cstruct = of_cstruct
+
 let to_cstruct (`Checked cs) = cs
+
+let pub_key_to_cstruct = to_cstruct
+
+let priv_key_to_cstruct = to_cstruct
 
 (* pk -> sk -> basepoint -> unit *)
 external scalarmult_raw :

--- a/src/hacl_x25519.mli
+++ b/src/hacl_x25519.mli
@@ -25,7 +25,7 @@ val key_length_bytes : int
     - call [public] on the private key. This returns the corresponding public
     key.
 *)
-type priv_key
+type secret
 
 (** Kind of errors. *)
 type error = [`Invalid_length]
@@ -33,20 +33,20 @@ type error = [`Invalid_length]
 val pp_error : Format.formatter -> error -> unit
 (** Pretty printer for errors *)
 
-val priv_key_of_cstruct : Cstruct.t -> (priv_key, error) result
+val priv_key_of_cstruct : Cstruct.t -> (secret, error) result
 (** Convert a [Cstruct.t] into a private key. Internally, this only checks that
     its length is [key_length_bytes]. If that is not the case, returns an error
     message. *)
 
-val priv_key_to_cstruct : priv_key -> Cstruct.t
+val priv_key_to_cstruct : secret -> Cstruct.t
 (** Return the [Cstruct.t] corresponding to a private key. It is always
     [key_length_bytes] bytes long. *)
 
-val public : priv_key -> Cstruct.t
+val public : secret -> Cstruct.t
 (** Compute the public part corresponding to a private key. Internally, this
     multiplies the curve's base point by the supplied scalar. *)
 
-val key_exchange : priv:priv_key -> pub:Cstruct.t -> (Cstruct.t, error) result
+val key_exchange : secret -> Cstruct.t -> (Cstruct.t, error) result
 (** Perform Diffie-Hellman key exchange between a private part and a public
     part.
 

--- a/src/hacl_x25519.mli
+++ b/src/hacl_x25519.mli
@@ -30,12 +30,18 @@ type priv_key
 (** A public key. In elliptic curve terms, a point. *)
 type pub_key
 
-val priv_key_of_cstruct : Cstruct.t -> (priv_key, string) result
+(** Kind of errors. *)
+type error = [`Invalid_length]
+
+val pp_error : Format.formatter -> error -> unit
+(** Pretty printer for errors *)
+
+val priv_key_of_cstruct : Cstruct.t -> (priv_key, error) result
 (** Convert a [Cstruct.t] into a private key. Internally, this only checks that its
     length is [key_length_bytes]. If that is not the case, returns an error
     message. *)
 
-val pub_key_of_cstruct : Cstruct.t -> (pub_key, string) result
+val pub_key_of_cstruct : Cstruct.t -> (pub_key, error) result
 (** Convert a [Cstruct.t] into a public key. Internally, this only checks that its
     length is [key_length_bytes]. If that is not the case, returns an error
     message. *)

--- a/src/hacl_x25519.mli
+++ b/src/hacl_x25519.mli
@@ -14,39 +14,38 @@
     use this in the context of TLS 1.3.
 *)
 
-
 val key_length_bytes : int
 (** The length of public and private keys, in bytes. Equal to 32. *)
 
-(** A cryptographic key (public or private).
+(** A private key. In elliptic curve terms, a scalar.
+
     To generate a key pair:
     - generate a random cstruct of length [key_length_bytes].
-    - call [of_cstruct] on it. This is the private key.
+    - call [priv_key_of_cstruct] on it. This is the private key.
     - call [public] on the private key. This returns the corresponding public
     key.
-
-    This uses phantom types to make [of_cstruct] and [to_cstruct] polymorphic in
-    the key type.
 *)
-type _ key
+type priv_key
 
-type priv
+(** A public key. In elliptic curve terms, a point. *)
+type pub_key
 
-(** A private key. In elliptic curve terms, a scalar. *)
-type priv_key = priv key
-
-type pub
-
-(** A private key. In elliptic curve terms, a point. *)
-type pub_key = pub key
-
-val of_cstruct : Cstruct.t -> (_ key, string) result
-(** Convert a [Cstruct.t] into a key. Internally, this only checks that its
+val priv_key_of_cstruct : Cstruct.t -> (priv_key, string) result
+(** Convert a [Cstruct.t] into a private key. Internally, this only checks that its
     length is [key_length_bytes]. If that is not the case, returns an error
     message. *)
 
-val to_cstruct : _ key -> Cstruct.t
-(** Return the [Cstruct.t] corresponding to a key. It is always
+val pub_key_of_cstruct : Cstruct.t -> (pub_key, string) result
+(** Convert a [Cstruct.t] into a public key. Internally, this only checks that its
+    length is [key_length_bytes]. If that is not the case, returns an error
+    message. *)
+
+val priv_key_to_cstruct : priv_key -> Cstruct.t
+(** Return the [Cstruct.t] corresponding to a private key. It is always
+    [key_length_bytes] bytes long. *)
+
+val pub_key_to_cstruct : pub_key -> Cstruct.t
+(** Return the [Cstruct.t] corresponding to a public key. It is always
     [key_length_bytes] bytes long. *)
 
 val public : priv_key -> pub_key

--- a/test/test.expected
+++ b/test/test.expected
@@ -1,19 +1,18 @@
-ok:
-9c 64 7d 9a e5 89 b9 f5  8f dc 3c a4 94 7e fb c9
-15 c4 b2 e0 8e 74 4a 0e  df 46 9d ac 59 c8 f8 5a
+public too short:
+error: Invalid key size
+public too long:
+error: Invalid key size
 
-public too short: error: Invalid key size
-public too long: error: Invalid key size
 alice_public:
 85 20 f0 09 89 30 a7 54  74 8b 7d dc b4 3e f7 5a
 0d bf 3a 0d 26 38 1a f4  eb a4 a9 8e aa 9b 4e 6a
 bob_public:
 de 9e db 7d 7b 7d c1 b4  d3 5b 61 c2 ec e4 35 37
 3f 83 43 c8 5b 78 67 4d  ad fc 7e 14 6f 88 2b 4f
-pub_a * priv_b =
+pub_a * priv_b:
 4a 5d 9d 5b a4 ce 2d e1  72 8e 3b f4 80 35 0f 25
 e0 7e 21 c9 47 d1 9e 33  76 f0 9b 3c 1e 16 17 42
-pub_b * priv_a =
+pub_b * priv_a:
 4a 5d 9d 5b a4 ce 2d e1  72 8e 3b f4 80 35 0f 25
 e0 7e 21 c9 47 d1 9e 33  76 f0 9b 3c 1e 16 17 42
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,8 +1,9 @@
 let key_to_string public =
-  Format.asprintf "%a" Cstruct.hexdump_pp (Hacl_x25519.to_cstruct public)
+  Format.asprintf "%a" Cstruct.hexdump_pp
+    (Hacl_x25519.pub_key_to_cstruct public)
 
 let test ~name x =
-  match Hacl_x25519.of_cstruct x with
+  match Hacl_x25519.pub_key_of_cstruct x with
   | Ok result ->
       Printf.printf "%s:\n%s\n" name (key_to_string result)
   | Error e ->
@@ -14,7 +15,8 @@ let get_ok = function
   | Error _ ->
       assert false
 
-let key_of_hex s = get_ok (Hacl_x25519.of_cstruct (Cstruct.of_hex s))
+let priv_key_of_hex s =
+  get_ok (Hacl_x25519.priv_key_of_cstruct (Cstruct.of_hex s))
 
 let too_short = Cstruct.create 31
 
@@ -32,14 +34,14 @@ let test_of_cstruct () =
     Data comes from RFC7748 6.1. *)
 let test_to_public () =
   let alice_private =
-    key_of_hex
+    priv_key_of_hex
       {| 77076d0a7318a57d3c16c17251b26645
          df4c2f87ebc0992ab177fba51db92c2a |}
   in
   let alice_public = Hacl_x25519.public alice_private in
   Printf.printf "alice_public:\n%s" (key_to_string alice_public);
   let bob_private =
-    key_of_hex
+    priv_key_of_hex
       {| 5dab087e624a8a4b79e17f8b83800ee6
          6f3bb1292618b6fd1c2f8b27ff88e0eb |}
   in

--- a/test/test.ml
+++ b/test/test.ml
@@ -7,7 +7,7 @@ let test ~name x =
   | Ok result ->
       Printf.printf "%s:\n%s\n" name (key_to_string result)
   | Error e ->
-      Printf.printf "%s: error: %s\n" name e
+      Format.printf "%s: error: %a\n" name Hacl_x25519.pp_error e
 
 let get_ok = function
   | Ok x ->

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,19 +1,18 @@
-let key_to_string public =
-  Format.asprintf "%a" Cstruct.hexdump_pp
-    (Hacl_x25519.pub_key_to_cstruct public)
-
-let test ~name x =
-  match Hacl_x25519.pub_key_of_cstruct x with
+let pp_result ppf = function
   | Ok result ->
-      Printf.printf "%s:\n%s\n" name (key_to_string result)
+      Cstruct.hexdump_pp ppf result
   | Error e ->
-      Format.printf "%s: error: %a\n" name Hacl_x25519.pp_error e
+      Format.fprintf ppf "error: %a@." Hacl_x25519.pp_error e
 
 let get_ok = function
   | Ok x ->
       x
   | Error _ ->
       assert false
+
+let test ~name ~pub ~priv =
+  let result = Hacl_x25519.key_exchange ~pub ~priv in
+  Format.printf "%s:@,%a@," name pp_result result
 
 let priv_key_of_hex s =
   get_ok (Hacl_x25519.priv_key_of_cstruct (Cstruct.of_hex s))
@@ -22,34 +21,26 @@ let too_short = Cstruct.create 31
 
 let too_long = Cstruct.create 33
 
-let test_of_cstruct () =
-  test ~name:"ok"
-    (Cstruct.of_hex
-       {| 9c647d9ae589b9f58fdc3ca4947efbc9
-          15c4b2e08e744a0edf469dac59c8f85a |});
-  test ~name:"public too short" too_short;
-  test ~name:"public too long" too_long
-
-(** Test private-to-public conversion.
+(** Test private-to-public conversion and key exchange.
     Data comes from RFC7748 6.1. *)
-let test_to_public () =
+let run_tests () =
   let alice_private =
     priv_key_of_hex
       {| 77076d0a7318a57d3c16c17251b26645
          df4c2f87ebc0992ab177fba51db92c2a |}
   in
+  test ~name:"public too short" ~priv:alice_private ~pub:too_short;
+  test ~name:"public too long" ~priv:alice_private ~pub:too_long;
   let alice_public = Hacl_x25519.public alice_private in
-  Printf.printf "alice_public:\n%s" (key_to_string alice_public);
+  Format.printf "alice_public:@.%a" Cstruct.hexdump_pp alice_public;
   let bob_private =
     priv_key_of_hex
       {| 5dab087e624a8a4b79e17f8b83800ee6
          6f3bb1292618b6fd1c2f8b27ff88e0eb |}
   in
   let bob_public = Hacl_x25519.public bob_private in
-  Format.printf "bob_public:\n%s" (key_to_string bob_public);
-  Format.printf "pub_a * priv_b =@,%a@," Cstruct.hexdump_pp
-    (Hacl_x25519.key_exchange ~pub:alice_public ~priv:bob_private);
-  Format.printf "pub_b * priv_a =@,%a@," Cstruct.hexdump_pp
-    (Hacl_x25519.key_exchange ~pub:bob_public ~priv:alice_private)
+  Format.printf "bob_public:@.%a" Cstruct.hexdump_pp bob_public;
+  test ~name:"pub_a * priv_b" ~pub:alice_public ~priv:bob_private;
+  test ~name:"pub_b * priv_a" ~pub:bob_public ~priv:alice_private
 
-let () = test_of_cstruct (); test_to_public ()
+let () = run_tests ()

--- a/test/test.ml
+++ b/test/test.ml
@@ -11,7 +11,7 @@ let get_ok = function
       assert false
 
 let test ~name ~pub ~priv =
-  let result = Hacl_x25519.key_exchange ~pub ~priv in
+  let result = Hacl_x25519.key_exchange priv pub in
   Format.printf "%s:@,%a@," name pp_result result
 
 let priv_key_of_hex s =

--- a/test_wycheproof/wycheproof_hacl.ml
+++ b/test_wycheproof/wycheproof_hacl.ml
@@ -16,8 +16,7 @@ let priv_of_string s =
   Hacl_x25519.priv_key_of_cstruct (Cstruct.of_string s) |> get_ok
 
 let key_exchange ~priv ~pub =
-  Hacl_x25519.key_exchange ~priv:(priv_of_string priv)
-    ~pub:(Cstruct.of_string pub)
+  Hacl_x25519.key_exchange (priv_of_string priv) (Cstruct.of_string pub)
   |> get_ok
   |> Cstruct.to_string
 

--- a/test_wycheproof/wycheproof_hacl.ml
+++ b/test_wycheproof/wycheproof_hacl.ml
@@ -6,24 +6,20 @@ let check pp equal name expected got =
     Format.printf "%s - error\nexpected:\n%a\ngot:\n%a\n" name pp expected pp
       got
 
-let priv_of_string s =
-  match Hacl_x25519.priv_key_of_cstruct (Cstruct.of_string s) with
+let get_ok = function
   | Ok x ->
       x
   | Error _ ->
       assert false
 
-let pub_of_string s =
-  match Hacl_x25519.pub_key_of_cstruct (Cstruct.of_string s) with
-  | Ok x ->
-      x
-  | Error _ ->
-      assert false
+let priv_of_string s =
+  Hacl_x25519.priv_key_of_cstruct (Cstruct.of_string s) |> get_ok
 
 let key_exchange ~priv ~pub =
-  Cstruct.to_string
-    (Hacl_x25519.key_exchange ~priv:(priv_of_string priv)
-       ~pub:(pub_of_string pub))
+  Hacl_x25519.key_exchange ~priv:(priv_of_string priv)
+    ~pub:(Cstruct.of_string pub)
+  |> get_ok
+  |> Cstruct.to_string
 
 let run_test {tcId; comment; private_; public; shared = expected; _} =
   let name = Printf.sprintf "%d - %s" tcId comment in

--- a/test_wycheproof/wycheproof_hacl.ml
+++ b/test_wycheproof/wycheproof_hacl.ml
@@ -6,8 +6,15 @@ let check pp equal name expected got =
     Format.printf "%s - error\nexpected:\n%a\ngot:\n%a\n" name pp expected pp
       got
 
-let of_string s =
-  match Hacl_x25519.of_cstruct (Cstruct.of_string s) with
+let priv_of_string s =
+  match Hacl_x25519.priv_key_of_cstruct (Cstruct.of_string s) with
+  | Ok x ->
+      x
+  | Error _ ->
+      assert false
+
+let pub_of_string s =
+  match Hacl_x25519.pub_key_of_cstruct (Cstruct.of_string s) with
   | Ok x ->
       x
   | Error _ ->
@@ -15,7 +22,8 @@ let of_string s =
 
 let key_exchange ~priv ~pub =
   Cstruct.to_string
-    (Hacl_x25519.key_exchange ~priv:(of_string priv) ~pub:(of_string pub))
+    (Hacl_x25519.key_exchange ~priv:(priv_of_string priv)
+       ~pub:(pub_of_string pub))
 
 let run_test {tcId; comment; private_; public; shared = expected; _} =
   let name = Printf.sprintf "%d - %s" tcId comment in


### PR DESCRIPTION
- remove key-type polymorphism
- use a polymorphic error type
- just use `secret` and `Cstruct.t`