### PR TITLE
Build bench exe in runtest (but do not run it)

### DIFF
--- a/bench/dune
+++ b/bench/dune
@@ -5,3 +5,7 @@
 (alias
  (name bench)
  (action (run ./bench.exe --all)))
+
+(alias
+ (name runtest)
+ (deps ./bench.exe))

--- a/hacl_x25519.opam
+++ b/hacl_x25519.opam
@@ -21,6 +21,7 @@ depends: [
   "yojson" {with-test & >= "1.6.0"}
   "hex" {with-test}
   "ppx_blob" {with-test}
+  "benchmark" {with-test}
 ]
 synopsis: "Primitives for Elliptic Curve Cryptography taken from Project Everest"
 description: """


### PR DESCRIPTION
This will ensure we don't accidentally break the benchmark even if it does not run in CI.