### PR TITLE
Check low order points

### DIFF
--- a/hacl_x25519.opam
+++ b/hacl_x25519.opam
@@ -17,6 +17,7 @@ build: [
 depends: [
   "dune" {build & >= "1.4.0"}
   "cstruct" {>= "3.5.0"}
+  "eqaf"
   "ppx_deriving_yojson" {with-test}
   "yojson" {with-test & >= "1.6.0"}
   "hex" {with-test}

--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,4 @@
 (library
  (public_name hacl_x25519)
- (libraries cstruct)
+ (libraries cstruct eqaf)
  (c_names hacl_x25519_stubs Hacl_Curve25519))

--- a/src/hacl_x25519.mli
+++ b/src/hacl_x25519.mli
@@ -28,7 +28,9 @@ val key_length_bytes : int
 type secret
 
 (** Kind of errors. *)
-type error = [`Invalid_length]
+type error =
+  [ `Invalid_length
+  | `Low_order ]
 
 val pp_error : Format.formatter -> error -> unit
 (** Pretty printer for errors *)
@@ -62,12 +64,8 @@ val key_exchange : secret -> Cstruct.t -> (Cstruct.t, error) result
     secret without transmitting any private information.
 
     As described in {{: https://tools.ietf.org/html/rfc7748#section-6.1} RFC
-    7748, section 6.1}, if this function operates on an input corresponding to
-    a point with small order, it will return an all-zero value.
-
-    Whether this is an error case or not depends on the protocol. {{:
-    https://tools.ietf.org/html/rfc8446#section-7.4.2} In the context of TLS
-    1.3}, "implementations MUST check whether the computed Diffie-Hellman shared
-    secret is the all-zero value and abort if so". This should be done in
-    constant time, for example by using the {{: https://github.com/mirage/eqaf/}
-    eqaf} library. *)
+    7748, section 6.1}, if this function operates on an input corresponding to a
+    point with small order, it internally generates an all-zero value. If this
+    is the case [Error `Low_order] will be returned instead. {{:
+    https://tools.ietf.org/html/rfc8446#section-7.4.2} This check is necessary
+    in the context of TLS 1.3}, but might not in other protocols. *)

--- a/test/test.expected
+++ b/test/test.expected
@@ -15,4 +15,6 @@ e0 7e 21 c9 47 d1 9e 33  76 f0 9b 3c 1e 16 17 42
 pub_b * priv_a:
 4a 5d 9d 5b a4 ce 2d e1  72 8e 3b f4 80 35 0f 25
 e0 7e 21 c9 47 d1 9e 33  76 f0 9b 3c 1e 16 17 42
+low order point:
+error: Public key with low order
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -22,7 +22,7 @@ let too_short = Cstruct.create 31
 let too_long = Cstruct.create 33
 
 (** Test private-to-public conversion and key exchange.
-    Data comes from RFC7748 6.1. *)
+    Data comes from RFC7748 6.1 and Wycheproof. *)
 let run_tests () =
   let alice_private =
     priv_key_of_hex
@@ -41,6 +41,17 @@ let run_tests () =
   let bob_public = Hacl_x25519.public bob_private in
   Format.printf "bob_public:@.%a" Cstruct.hexdump_pp bob_public;
   test ~name:"pub_a * priv_b" ~pub:alice_public ~priv:bob_private;
-  test ~name:"pub_b * priv_a" ~pub:bob_public ~priv:alice_private
+  test ~name:"pub_b * priv_a" ~pub:bob_public ~priv:alice_private;
+  let low_order_pub =
+    Cstruct.of_hex
+      {| e0eb7a7c3b41b8ae1656e3faf19fc46a
+         da098deb9c32b1fd866205165f49b800 |}
+  in
+  let low_order_priv =
+    priv_key_of_hex
+      {| 10255c9230a97a30a458ca284a629669
+         293a31890cda9d147febc7d1e22d6bb1 |}
+  in
+  test ~name:"low order point" ~pub:low_order_pub ~priv:low_order_priv
 
 let () = run_tests ()


### PR DESCRIPTION
X25519 returns all zeroes if public key has low order. This is meant to be checked by the caller depending on the protocol. In our case, we're only interested in TLS, so this adds an extra error case.