### PR TITLE
ocamlformat: use conventional profile

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,7 +1,1 @@
-break-cases=all
-break-infix=fit-or-vertical
-field-space=loose
-margin=79
-parens-tuple=always
-sequence-style=terminator
-type-decl=sparse
+profile=conventional

--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -1,7 +1,8 @@
 let read_urandom n =
   let ic = Pervasives.open_in_bin "/dev/urandom" in
   let s = Pervasives.really_input_string ic n in
-  close_in ic; Cstruct.of_string s
+  close_in ic;
+  Cstruct.of_string s
 
 let generate_key_pair () = Hacl_x25519.gen_key ~rng:read_urandom
 
@@ -9,10 +10,10 @@ let bench_dh () =
   let priv, _ = generate_key_pair () in
   let _, pub = generate_key_pair () in
   let run () : (Cstruct.t, _) result = Hacl_x25519.key_exchange priv pub in
-  Benchmark.throughputN 1 [("X25519", run, ())]
+  Benchmark.throughputN 1 [ ("X25519", run, ()) ]
 
 let () =
   let open Benchmark.Tree in
-  register @@ "Hacl" @>>> ["dh" @> lazy (bench_dh ())]
+  register @@ "Hacl" @>>> [ "dh" @> lazy (bench_dh ()) ]
 
 let () = Benchmark.Tree.run_global ()

--- a/bench/dune
+++ b/bench/dune
@@ -4,7 +4,8 @@
 
 (alias
  (name bench)
- (action (run ./bench.exe --all)))
+ (action
+  (run ./bench.exe --all)))
 
 (alias
  (name runtest)

--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,3 @@
-(lang dune 1.4)
+(lang dune 1.7)
 (name hacl_x25519)
-(using fmt 1.0)
+(using fmt 1.1)

--- a/hacl_x25519.opam
+++ b/hacl_x25519.opam
@@ -15,7 +15,7 @@ build: [
  ["dune" "runtest" "-p" name] {with-test}
 ]
 depends: [
-  "dune" {build & >= "1.7.0"}
+  "dune" {>= "1.7.0"}
   "cstruct" {>= "3.5.0"}
   "eqaf"
   "ppx_deriving_yojson" {with-test}

--- a/hacl_x25519.opam
+++ b/hacl_x25519.opam
@@ -15,7 +15,7 @@ build: [
  ["dune" "runtest" "-p" name] {with-test}
 ]
 depends: [
-  "dune" {build & >= "1.4.0"}
+  "dune" {build & >= "1.7.0"}
   "cstruct" {>= "3.5.0"}
   "eqaf"
   "ppx_deriving_yojson" {with-test}

--- a/src/hacl_x25519.ml
+++ b/src/hacl_x25519.ml
@@ -1,25 +1,18 @@
 let key_length_bytes = 32
 
-let ( >>= ) r f =
-  match r with
-  | Ok x ->
-      f x
-  | Error _ as e ->
-      e
+let ( >>= ) r f = match r with Ok x -> f x | Error _ as e -> e
 
-let ( >>| ) r f = r >>= fun x -> Ok (f x)
+let ( >>| ) r f =
+  r >>= fun x ->
+  Ok (f x)
 
-type error =
-  [ `Invalid_length
-  | `Low_order ]
+type error = [ `Invalid_length | `Low_order ]
 
 let pp_error ppf = function
-  | `Invalid_length ->
-      Format.fprintf ppf "Invalid key size"
-  | `Low_order ->
-      Format.fprintf ppf "Public key with low order"
+  | `Invalid_length -> Format.fprintf ppf "Invalid key size"
+  | `Low_order -> Format.fprintf ppf "Public key with low order"
 
-type secret = [`Checked of Cstruct.t]
+type secret = [ `Checked of Cstruct.t ]
 
 let key_of_cstruct cs =
   if Cstruct.len cs = key_length_bytes then Ok (`Checked cs)
@@ -46,15 +39,14 @@ let is_zero_output cs =
   Eqaf.equal s all_zeroes
 
 let key_exchange priv pub =
-  key_of_cstruct pub
-  >>| checked_buffer
-  >>= fun checked_pub ->
+  key_of_cstruct pub >>| checked_buffer >>= fun checked_pub ->
   let shared = key_exchange_buffer ~priv ~checked_pub in
   if is_zero_output shared then Error `Low_order else Ok shared
 
 let basepoint =
   let cs = Cstruct.create key_length_bytes in
-  Cstruct.set_uint8 cs 0 9; Cstruct.to_bigarray cs
+  Cstruct.set_uint8 cs 0 9;
+  Cstruct.to_bigarray cs
 
 let public priv = key_exchange_buffer ~priv ~checked_pub:basepoint
 
@@ -62,8 +54,7 @@ let gen_key ~rng =
   let secret_cstruct = rng key_length_bytes in
   let secret =
     match key_of_cstruct secret_cstruct with
-    | Ok k ->
-        k
+    | Ok k -> k
     | Error `Invalid_length ->
         failwith "Hacl_x25519.gen_key: generator returned an invalid length"
   in

--- a/src/hacl_x25519.mli
+++ b/src/hacl_x25519.mli
@@ -14,11 +14,11 @@
     use this in the context of TLS 1.3.
 *)
 
+type secret
 (** Key material. In elliptic curve terms, a scalar.
 
     To generate a key pair, use [gen_key].
 *)
-type secret
 
 val gen_key : rng:(int -> Cstruct.t) -> secret * Cstruct.t
 (** Generate a key pair. [rng] should return a [Cstruct.t] with the specified
@@ -27,10 +27,8 @@ val gen_key : rng:(int -> Cstruct.t) -> secret * Cstruct.t
     If the cstruct returned by [rng] does not have the correct length, raises
     [Failure _]. *)
 
+type error = [ `Invalid_length | `Low_order ]
 (** Kind of errors. *)
-type error =
-  [ `Invalid_length
-  | `Low_order ]
 
 val pp_error : Format.formatter -> error -> unit
 (** Pretty printer for errors *)

--- a/test/dune
+++ b/test/dune
@@ -1,4 +1,3 @@
 (test
  (name test)
- (libraries hacl_x25519 hex)
-)
+ (libraries hacl_x25519 hex))

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,8 +1,6 @@
 let pp_result ppf = function
-  | Ok result ->
-      Cstruct.hexdump_pp ppf result
-  | Error e ->
-      Format.fprintf ppf "error: %a@." Hacl_x25519.pp_error e
+  | Ok result -> Cstruct.hexdump_pp ppf result
+  | Error e -> Format.fprintf ppf "error: %a@." Hacl_x25519.pp_error e
 
 let test ~name ~pub ~priv =
   let result = Hacl_x25519.key_exchange priv pub in

--- a/test_wycheproof/dune
+++ b/test_wycheproof/dune
@@ -1,4 +1,3 @@
 (test
  (name wycheproof_hacl)
- (libraries hacl_x25519 wycheproof)
-)
+ (libraries hacl_x25519 wycheproof))

--- a/test_wycheproof/wycheproof/dune
+++ b/test_wycheproof/wycheproof/dune
@@ -1,6 +1,6 @@
 (library
  (name wycheproof)
  (libraries yojson ppx_deriving_yojson.runtime hex)
- (preprocess (pps ppx_deriving.std ppx_deriving_yojson ppx_blob))
- (preprocessor_deps x25519_test.json)
-)
+ (preprocess
+  (pps ppx_deriving.std ppx_deriving_yojson ppx_blob))
+ (preprocessor_deps x25519_test.json))

--- a/test_wycheproof/wycheproof/wycheproof.ml
+++ b/test_wycheproof/wycheproof/wycheproof.ml
@@ -13,77 +13,57 @@ let pp_hex fmt s =
 let hex_of_yojson json =
   let padded s = if String.length s mod 2 = 0 then s else "0" ^ s in
   match [%of_yojson: string] json with
-  | Ok s ->
-      Ok (Hex.to_string (`Hex (padded s)))
-  | Error _ as e ->
-      e
+  | Ok s -> Ok (Hex.to_string (`Hex (padded s)))
+  | Error _ as e -> e
 
-type test_result =
-  | Valid
-  | Acceptable
-  | Invalid
-[@@deriving show]
+type test_result = Valid | Acceptable | Invalid [@@deriving show]
 
 let test_result_of_yojson = function
-  | `String "valid" ->
-      Ok Valid
-  | `String "acceptable" ->
-      Ok Acceptable
-  | `String "invalid" ->
-      Ok Invalid
-  | _ ->
-      Error "test_result"
+  | `String "valid" -> Ok Valid
+  | `String "acceptable" -> Ok Acceptable
+  | `String "invalid" -> Ok Invalid
+  | _ -> Error "test_result"
 
-type flag =
-  | Twist
-  | LowOrderPublic
-  | SmallPublicKey
-[@@deriving show]
+type flag = Twist | LowOrderPublic | SmallPublicKey [@@deriving show]
 
 let flag_of_yojson = function
-  | `String "LowOrderPublic" ->
-      Ok LowOrderPublic
-  | `String "Twist" ->
-      Ok Twist
-  | `String "Small public key" ->
-      Ok SmallPublicKey
-  | `String s ->
-      Error ("Unknown flag: " ^ s)
-  | _ ->
-      Error "flag_of_yojson"
+  | `String "LowOrderPublic" -> Ok LowOrderPublic
+  | `String "Twist" -> Ok Twist
+  | `String "Small public key" -> Ok SmallPublicKey
+  | `String s -> Error ("Unknown flag: " ^ s)
+  | _ -> Error "flag_of_yojson"
 
-type test =
-  { tcId : int
-  ; comment : string
-  ; curve : json option [@yojson.default None]
-  ; public : hex
-  ; private_ : hex [@yojson.key "private"]
-  ; shared : hex
-  ; result : test_result
-  ; flags : flag list }
+type test = {
+  tcId : int;
+  comment : string;
+  curve : json option; [@yojson.default None]
+  public : hex;
+  private_ : hex; [@yojson.key "private"]
+  shared : hex;
+  result : test_result;
+  flags : flag list;
+}
 [@@deriving of_yojson, show]
 
-type test_group =
-  { curve : json
-  ; tests : test list
-  ; encoding : json option [@yojson.default None]
-  ; type_ : json option [@yojson.default None] [@yojson.key "type"] }
+type test_group = {
+  curve : json;
+  tests : test list;
+  encoding : json option; [@yojson.default None]
+  type_ : json option; [@yojson.default None] [@yojson.key "type"]
+}
 [@@deriving of_yojson, show]
 
-type test_file =
-  { algorithm : json
-  ; generatorVersion : json
-  ; header : json
-  ; notes : json
-  ; numberOfTests : json
-  ; testGroups : test_group list }
+type test_file = {
+  algorithm : json;
+  generatorVersion : json;
+  header : json;
+  notes : json;
+  numberOfTests : json;
+  testGroups : test_group list;
+}
 [@@deriving of_yojson, show]
 
-let get_json = function
-  | Ok x ->
-      x
-  | Error s ->
-      failwith s
+let get_json = function Ok x -> x | Error s -> failwith s
 
 let load_tests s =
   Yojson.Safe.from_string s |> [%of_yojson: test_file] |> get_json

--- a/test_wycheproof/wycheproof/wycheproof.mli
+++ b/test_wycheproof/wycheproof/wycheproof.mli
@@ -4,39 +4,38 @@ type hex = string [@@deriving eq]
 
 val pp_hex : Format.formatter -> hex -> unit
 
-type test_result =
-  | Valid
-  | Acceptable
-  | Invalid
-[@@deriving show]
+type test_result = Valid | Acceptable | Invalid [@@deriving show]
 
 type flag [@@deriving show]
 
-type test =
-  { tcId : int
-  ; comment : string
-  ; curve : json option
-  ; public : hex
-  ; private_ : hex
-  ; shared : hex
-  ; result : test_result
-  ; flags : flag list }
+type test = {
+  tcId : int;
+  comment : string;
+  curve : json option;
+  public : hex;
+  private_ : hex;
+  shared : hex;
+  result : test_result;
+  flags : flag list;
+}
 [@@deriving show]
 
-type test_group =
-  { curve : json
-  ; tests : test list
-  ; encoding : json option
-  ; type_ : json option }
+type test_group = {
+  curve : json;
+  tests : test list;
+  encoding : json option;
+  type_ : json option;
+}
 [@@deriving show]
 
-type test_file =
-  { algorithm : json
-  ; generatorVersion : json
-  ; header : json
-  ; notes : json
-  ; numberOfTests : json
-  ; testGroups : test_group list }
+type test_file = {
+  algorithm : json;
+  generatorVersion : json;
+  header : json;
+  notes : json;
+  numberOfTests : json;
+  testGroups : test_group list;
+}
 [@@deriving show]
 
 val x25519 : test_file

--- a/test_wycheproof/wycheproof_hacl.ml
+++ b/test_wycheproof/wycheproof_hacl.ml
@@ -6,11 +6,7 @@ let check pp equal name expected got =
     Format.printf "%s - error\nexpected:\n%a\ngot:\n%a\n" name pp expected pp
       got
 
-let get_ok = function
-  | Ok x ->
-      x
-  | Error _ ->
-      assert false
+let get_ok = function Ok x -> x | Error _ -> assert false
 
 let key_pair_of_cstruct data = Hacl_x25519.gen_key ~rng:(fun _ -> data)
 
@@ -20,14 +16,11 @@ let key_exchange ~priv ~pub =
   match
     Hacl_x25519.key_exchange (priv_of_string priv) (Cstruct.of_string pub)
   with
-  | Ok cs ->
-      Ok (Cstruct.to_string cs)
-  | Error `Low_order ->
-      Ok (String.make 32 '\x00')
-  | Error _ as e ->
-      e
+  | Ok cs -> Ok (Cstruct.to_string cs)
+  | Error `Low_order -> Ok (String.make 32 '\x00')
+  | Error _ as e -> e
 
-let run_test {tcId; comment; private_; public; shared = expected; _} =
+let run_test { tcId; comment; private_; public; shared = expected; _ } =
   let name = Printf.sprintf "%d - %s" tcId comment in
   let got = get_ok (key_exchange ~priv:private_ ~pub:public) in
   check Wycheproof.pp_hex Wycheproof.equal_hex name expected got


### PR DESCRIPTION
It seems that we're converging around `profile=conventional` so let's switch now (and format dune files).