### PR TITLE
register ocaml as dependency

### DIFF
--- a/hacl_x25519.opam
+++ b/hacl_x25519.opam
@@ -15,6 +15,7 @@ build: [
  ["dune" "runtest" "-p" name] {with-test}
 ]
 depends: [
+  "ocaml"
   "dune" {>= "1.7.0"}
   "cstruct" {>= "3.5.0"}
   "eqaf"


### PR DESCRIPTION
~~this exposes the function `of_cstruct : Cstruct.t -> (secret * Cstruct.t, error) result` to inject hardcoded (e.g. provided with test vectors) keys into the system. the documentation string attempts to be clear about its usage restrictions (only for testing).~~