### PR TITLE
freestanding & xen cross-compilation runes

### DIFF
--- a/META.hacl_x25519.template
+++ b/META.hacl_x25519.template
@@ -1,0 +1,4 @@
+# DUNE_GEN
+
+xen_linkopts = "-l:xen/libhacl_x25519_xen_stubs.a"
+freestanding_linkopts = "-l:freestanding/libhacl_x25519_freestanding_stubs.a"

--- a/freestanding/cflags.sh
+++ b/freestanding/cflags.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+export PKG_CONFIG_PATH="$(opam config var lib)/pkgconfig"
+flags="$(pkg-config --static ocaml-freestanding --cflags)"
+echo "($flags)"

--- a/freestanding/dune
+++ b/freestanding/dune
@@ -1,8 +1,13 @@
 (copy_files# ../src/hacl_x25519_stubs.c)
+
 (copy_files# ../src/Hacl_Curve25519.c)
+
 (copy_files# ../src/Hacl_Curve25519.h)
+
 (copy_files# ../src/FStar.h)
+
 (copy_files# ../src/kremlib_base.h)
+
 (copy_files# ../src/kremlib.h)
 
 (library
@@ -10,7 +15,11 @@
  (public_name hacl_x25519.freestanding)
  (optional)
  (libraries ocaml-freestanding)
- (c_flags (:include cflags-freestanding.sexp))
+ (c_flags
+  (:include cflags-freestanding.sexp))
  (c_names hacl_x25519_stubs Hacl_Curve25519))
 
-(rule (with-stdout-to cflags-freestanding.sexp (run ./cflags.sh)))
+(rule
+ (with-stdout-to
+  cflags-freestanding.sexp
+  (run ./cflags.sh)))

--- a/freestanding/dune
+++ b/freestanding/dune
@@ -1,0 +1,16 @@
+(copy_files# ../src/hacl_x25519_stubs.c)
+(copy_files# ../src/Hacl_Curve25519.c)
+(copy_files# ../src/Hacl_Curve25519.h)
+(copy_files# ../src/FStar.h)
+(copy_files# ../src/kremlib_base.h)
+(copy_files# ../src/kremlib.h)
+
+(library
+ (name hacl_x25519_freestanding)
+ (public_name hacl_x25519.freestanding)
+ (optional)
+ (libraries ocaml-freestanding)
+ (c_flags (:include cflags-freestanding.sexp))
+ (c_names hacl_x25519_stubs Hacl_Curve25519))
+
+(rule (with-stdout-to cflags-freestanding.sexp (run ./cflags.sh)))

--- a/hacl_x25519.opam
+++ b/hacl_x25519.opam
@@ -36,3 +36,11 @@ depends: [
   "stdlib-shims" {with-test}
   "yojson" {with-test & >= "1.6.0"}
 ]
+depopts: [
+  "mirage-xen-posix"
+  "ocaml-freestanding"
+]
+conflicts: [
+  "mirage-xen" {< "3.1.0"}
+  "ocaml-freestanding" {< "0.4.1"}
+]

--- a/src/kremlib.h
+++ b/src/kremlib.h
@@ -442,6 +442,9 @@ inline static int64_t FStar_UInt64_v(int64_t x) { return x; }
 #ifndef KRML_NOUINT128
 typedef unsigned __int128 FStar_UInt128_t, FStar_UInt128_t_, uint128_t;
 
+#ifndef PRIu64
+#define PRIu64 "lu"
+#endif
 static inline void print128(const char *where, uint128_t n) {
   KRML_HOST_PRINTF("%s: [%" PRIu64 ",%" PRIu64 "]\n", where,
                    (uint64_t)(n >> 64), (uint64_t)n);

--- a/src/kremlib_base.h
+++ b/src/kremlib_base.h
@@ -23,7 +23,7 @@
 #ifndef __KREMLIB_BASE_H
 #define __KREMLIB_BASE_H
 
-#include <inttypes.h>
+#include <stdint.h>
 #include <limits.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/xen/cflags.sh
+++ b/xen/cflags.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+export PKG_CONFIG_PATH="$(opam config var lib)/pkgconfig"
+flags="$(pkg-config --static mirage-xen-posix --cflags)"
+echo "($flags)"

--- a/xen/dune
+++ b/xen/dune
@@ -1,0 +1,16 @@
+(copy_files# ../src/hacl_x25519_stubs.c)
+(copy_files# ../src/Hacl_Curve25519.c)
+(copy_files# ../src/Hacl_Curve25519.h)
+(copy_files# ../src/FStar.h)
+(copy_files# ../src/kremlib_base.h)
+(copy_files# ../src/kremlib.h)
+
+(library
+ (name hacl_x25519_xen)
+ (public_name hacl_x25519.xen)
+ (optional)
+ (libraries mirage-xen-posix)
+ (c_flags (:include cflags-xen.sexp))
+ (c_names hacl_x25519_stubs Hacl_Curve25519))
+
+(rule (with-stdout-to cflags-xen.sexp (run ./cflags.sh)))

--- a/xen/dune
+++ b/xen/dune
@@ -1,8 +1,13 @@
 (copy_files# ../src/hacl_x25519_stubs.c)
+
 (copy_files# ../src/Hacl_Curve25519.c)
+
 (copy_files# ../src/Hacl_Curve25519.h)
+
 (copy_files# ../src/FStar.h)
+
 (copy_files# ../src/kremlib_base.h)
+
 (copy_files# ../src/kremlib.h)
 
 (library
@@ -10,7 +15,11 @@
  (public_name hacl_x25519.xen)
  (optional)
  (libraries mirage-xen-posix)
- (c_flags (:include cflags-xen.sexp))
+ (c_flags
+  (:include cflags-xen.sexp))
  (c_names hacl_x25519_stubs Hacl_Curve25519))
 
-(rule (with-stdout-to cflags-xen.sexp (run ./cflags.sh)))
+(rule
+ (with-stdout-to
+  cflags-xen.sexp
+  (run ./cflags.sh)))


### PR DESCRIPTION
not sure whether there's a better way (and if so, which) to not modify `kremlib_base.h` (with `#include <inttypes.h>` -> `#include <stdint.h>`) and `kremlb.h` (with `#ifndef PRIu64 #define PRIu64 "lu" #endif`)