### PR TITLE
revert changes to kremlib*h (new ocaml-freestanding no longer needs them)

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -22,6 +22,10 @@
   (ppx_deriving_yojson :with-test)
   (stdlib-shims :with-test)
   (yojson (and :with-test (>= 1.6.0))))
+ (depopts mirage-xen-posix ocaml-freestanding)
+ (conflicts
+  (mirage-xen-posix (< 3.1.0))
+  (ocaml-freestanding (< 0.6.0)))
  (synopsis "Primitives for Elliptic Curve Cryptography taken from Project Everest")
  (description
    "\> This is an implementation of the X25519 key exchange algorithm, using code from

--- a/freestanding/dune
+++ b/freestanding/dune
@@ -1,8 +1,13 @@
 (copy_files# ../src/hacl_x25519_stubs.c)
+
 (copy_files# ../src/Hacl_Curve25519.c)
+
 (copy_files# ../src/Hacl_Curve25519.h)
+
 (copy_files# ../src/FStar.h)
+
 (copy_files# ../src/kremlib_base.h)
+
 (copy_files# ../src/kremlib.h)
 
 (library
@@ -10,7 +15,11 @@
  (public_name hacl_x25519.freestanding)
  (optional)
  (libraries ocaml-freestanding)
- (c_flags (:include cflags-freestanding.sexp))
+ (c_flags
+  (:include cflags-freestanding.sexp))
  (c_names hacl_x25519_stubs Hacl_Curve25519))
 
-(rule (with-stdout-to cflags-freestanding.sexp (run ./cflags.sh)))
+(rule
+ (with-stdout-to
+  cflags-freestanding.sexp
+  (run ./cflags.sh)))

--- a/hacl_x25519.opam
+++ b/hacl_x25519.opam
@@ -36,11 +36,8 @@ depends: [
   "stdlib-shims" {with-test}
   "yojson" {with-test & >= "1.6.0"}
 ]
-depopts: [
-  "mirage-xen-posix"
-  "ocaml-freestanding"
-]
 conflicts: [
-  "mirage-xen" {< "3.1.0"}
-  "ocaml-freestanding" {< "0.4.1"}
+  "mirage-xen-posix" {< "3.1.0"}
+  "ocaml-freestanding" {< "0.6.0"}
 ]
+depopts: ["mirage-xen-posix" "ocaml-freestanding"]

--- a/src/kremlib.h
+++ b/src/kremlib.h
@@ -442,9 +442,6 @@ inline static int64_t FStar_UInt64_v(int64_t x) { return x; }
 #ifndef KRML_NOUINT128
 typedef unsigned __int128 FStar_UInt128_t, FStar_UInt128_t_, uint128_t;
 
-#ifndef PRIu64
-#define PRIu64 "lu"
-#endif
 static inline void print128(const char *where, uint128_t n) {
   KRML_HOST_PRINTF("%s: [%" PRIu64 ",%" PRIu64 "]\n", where,
                    (uint64_t)(n >> 64), (uint64_t)n);

--- a/src/kremlib_base.h
+++ b/src/kremlib_base.h
@@ -23,7 +23,7 @@
 #ifndef __KREMLIB_BASE_H
 #define __KREMLIB_BASE_H
 
-#include <stdint.h>
+#include <inttypes.h>
 #include <limits.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/xen/dune
+++ b/xen/dune
@@ -1,8 +1,13 @@
 (copy_files# ../src/hacl_x25519_stubs.c)
+
 (copy_files# ../src/Hacl_Curve25519.c)
+
 (copy_files# ../src/Hacl_Curve25519.h)
+
 (copy_files# ../src/FStar.h)
+
 (copy_files# ../src/kremlib_base.h)
+
 (copy_files# ../src/kremlib.h)
 
 (library
@@ -10,7 +15,11 @@
  (public_name hacl_x25519.xen)
  (optional)
  (libraries mirage-xen-posix)
- (c_flags (:include cflags-xen.sexp))
+ (c_flags
+  (:include cflags-xen.sexp))
  (c_names hacl_x25519_stubs Hacl_Curve25519))
 
-(rule (with-stdout-to cflags-xen.sexp (run ./cflags.sh)))
+(rule
+ (with-stdout-to
+  cflags-xen.sexp
+  (run ./cflags.sh)))


### PR DESCRIPTION
adapt dune-project

this reverts the changes to kremlib done in #29