### PR TITLE
Follow dune's documentation about diffing results

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -3,12 +3,16 @@
  (modules test)
  (libraries hacl_x25519 hex))
 
-(rule (with-stdout-to test.output (run ./test.exe)))
+(rule
+ (with-stdout-to
+  test.output
+  (run ./test.exe)))
 
 (rule
  (alias runtest)
  (package hacl_x25519)
- (action (diff test.expected test.output)))
+ (action
+  (diff test.expected test.output)))
 
 (test
  (name rfc8032)

--- a/test/dune
+++ b/test/dune
@@ -1,8 +1,14 @@
-(test
+(executable
  (name test)
- (package hacl_x25519)
  (modules test)
  (libraries hacl_x25519 hex))
+
+(rule (with-stdout-to test.output (run ./test.exe)))
+
+(rule
+ (alias runtest)
+ (package hacl_x25519)
+ (action (diff test.expected test.output)))
 
 (test
  (name rfc8032)

--- a/test_wycheproof/dune
+++ b/test_wycheproof/dune
@@ -1,3 +1,9 @@
-(test
+(executable
  (name wycheproof_hacl)
  (libraries hacl_x25519 wycheproof))
+
+(rule (with-stdout-to wycheproof_hacl.output (run ./wycheproof_hacl.exe)))
+
+(rule
+ (alias runtest)
+ (action (diff wycheproof_hacl.expected wycheproof_hacl.output)))

--- a/test_wycheproof/dune
+++ b/test_wycheproof/dune
@@ -2,8 +2,12 @@
  (name wycheproof_hacl)
  (libraries hacl_x25519 wycheproof))
 
-(rule (with-stdout-to wycheproof_hacl.output (run ./wycheproof_hacl.exe)))
+(rule
+ (with-stdout-to
+  wycheproof_hacl.output
+  (run ./wycheproof_hacl.exe)))
 
 (rule
  (alias runtest)
- (action (diff wycheproof_hacl.expected wycheproof_hacl.output)))
+ (action
+  (diff wycheproof_hacl.expected wycheproof_hacl.output)))


### PR DESCRIPTION
I updated tests to have the same layout than [the `dune`'s documentation](https://dune.readthedocs.io/en/stable/tests.html?highlight=diff#diffing-the-result) about _diffing results_.

It seems that `dune runtest` correctly compiles and run tests but it does not show results __if `diff` does not return an error__ (which is not user-friendly indeed). However, with `dune runtest --verbose`, we can ensure an execution of them. So I believe it's fine - try to fix #37.