### PR TITLE
provide Hacl_x25519.encode_secret and Hacl_ed25519.encode_priv functions to serialise private keys onto disk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## v0.2.0 (2020-07-28)
+
+- interface and expose Ed25519 code in the Hacl_ed25519 module (#35 @hannesm)
+- update C code to hacl-star-raw 0.2.1, adds 32 bit support (#36 @dinosaure)
+- provide Hacl_x25519.encode_secret and Hacl_ed25519.encode_priv (#41 @hannesm)
+
 ## v0.1.1 (2020-05-09)
 
 - adapt opam file from opam-repository (add ocaml dependency) #24, @hannesm

--- a/src/hacl_ed25519.ml
+++ b/src/hacl_ed25519.ml
@@ -8,6 +8,8 @@ let priv cs =
   if Cstruct.len cs = key_length_bytes then `Checked cs
   else invalid_arg "Invalid length"
 
+let encode_priv (`Checked cs) = cs
+
 external s_to_p : Cstruct.buffer -> Cstruct.buffer -> unit
   = "ml_Hacl_Ed25519_secret_to_public"
   [@@noalloc]

--- a/src/hacl_ed25519.mli
+++ b/src/hacl_ed25519.mli
@@ -8,6 +8,9 @@ val priv : Cstruct.t -> priv
 
     @raise Invalid_argument if [p] is not 32 bytes. *)
 
+val encode_priv : priv -> Cstruct.t
+(** [encode_priv p] is the private key encoded into a buffer. *)
+
 val priv_to_public : priv -> Cstruct.t
 (** [priv_to_public p] outputs the public key of [p]. *)
 

--- a/src/hacl_x25519.ml
+++ b/src/hacl_x25519.ml
@@ -60,3 +60,5 @@ let gen_key ~rng =
   in
   let pub_key = public secret in
   (secret, pub_key)
+
+let encode_secret (`Checked cs) = cs

--- a/src/hacl_x25519.mli
+++ b/src/hacl_x25519.mli
@@ -34,6 +34,9 @@ val gen_key : rng:(int -> Cstruct.t) -> secret * Cstruct.t
     If the cstruct returned by [rng] does not have the correct length, raises
     [Failure _]. *)
 
+val encode_secret : secret -> Cstruct.t
+(** [encode_secret secret] is the secret encoded into a buffer. *)
+
 type error = [ `Invalid_length | `Low_order ]
 (** Kind of errors. *)
 


### PR DESCRIPTION
this is to support writing private key files, as defined by OpenSSH (https://cvsweb.openbsd.org/cgi-bin/cvsweb/~checkout~/src/usr.bin/ssh/PROTOCOL.key?rev=1.1&content-type=text/plain -- which for some reason dumps 64 byte) and X.509 pem (RFC8410 specifies the OID for X25519 and Ed25519).

to unblock #39 