### PR TITLE
Add support for older compiler versions

### DIFF
--- a/src/evercrypt_targetconfig.h
+++ b/src/evercrypt_targetconfig.h
@@ -16,8 +16,10 @@
 #define EVERCRYPT_TARGETCONFIG_AARCH32 1
 #endif
 
+#if defined __has_include
 #if __has_include("config.h")
 #include "config.h"
+#endif
 #endif
 
 #if defined(__GNUC__) && !defined(BROKEN_INLINE_ASM)


### PR DESCRIPTION
Old compiler version such as GCC shipped in oraclelinux does not have `__has_include` and make opam-repo-ci fail in multiple occasion. e.g.

https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/07b1db6b6d350fd43c69950d24ffecd41a25efaa/variant/distributions,centos-7,dns-certify.4.6.3

This should take care of the problem